### PR TITLE
Fix VitePress build failure in MachineLock docs

### DIFF
--- a/docs/modules/MachineLock.md
+++ b/docs/modules/MachineLock.md
@@ -68,7 +68,7 @@ MachineLock 启用后会接管输入与界面控制：按配置联动静音、�
   类型：组合框；默认："Custom Hotkey (Notice Keyboard Lock)"。紧急退出通道。
   可选：Off（关闭）；Esc (Press 20 seconds)（Esc 键 (长按 20 秒)）；Custom Hotkey (Notice Keyboard Lock)（自定义快捷键 (注意键盘锁)）。
 - Custom Escape Hotkey（自定义退出快捷键）
-  类型：按键/复合；默认：{{"Keybind", {VK_OEM_3}}}。紧急退出热键，建议先实测在当前键盘锁策略下可触发。
+  类型：按键/复合；默认：`&#123;&#123;"Keybind", {VK_OEM_3}&#125;&#125;`。紧急退出热键，建议先实测在当前键盘锁策略下可触发。
 - Exit Condition（退出条件）
   类型：组合框；默认："Password"。常规退出条件。
   可选：Password（密码）；Wait Duration（等待一段时间）。


### PR DESCRIPTION
### Motivation
- VitePress build was failing because `docs/modules/MachineLock.md` contained a raw `{{ ... }}` sequence (`{{"Keybind", {VK_OEM_3}}}`) that Vue attempted to parse as an interpolation and produced a JS parse error.

### Description
- Escape the template-like braces inside inline code to prevent Vue interpolation by replacing the default value with ``&#123;&#123;"Keybind", {VK_OEM_3}&#125;&#125;`` in `docs/modules/MachineLock.md` so the literal value renders correctly.

### Testing
- Ran `npm run docs:build` and confirmed the documentation build completes successfully after the change (previously failed with a Vue interpolation parse error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999c659b0fc8333a7b96211bdb7ddb5)